### PR TITLE
Fix Python config JSDoc typo

### DIFF
--- a/src/constants/configs/python.ts
+++ b/src/constants/configs/python.ts
@@ -1,5 +1,5 @@
 /**
- * Compiles the users javascript config file for deployments.
+ * Compiles the users Python config file for deployments.
  * @param projectName - The name of the project, from either package.json or the dir name.
  * @returns {String} A docstring containing the config object.
  */


### PR DESCRIPTION
## Summary
- update the description in `src/constants/configs/python.ts`

## Testing
- `npm test` *(fails: tsx not found)*