### PR TITLE
Switch tests to Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {},
+};

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 		"dev": "tsc --watch",
 		"lint": "prettier --check . && xo",
 		"lint:fix": "prettier --write . && xo --fix",
-		"test": "tsx test.ts",
-		"start": "tsx src/cli.tsx"
+                "test": "jest",
+                "start": "tsx src/cli.tsx"
 	},
 	"files": [
 		"dist"
@@ -49,10 +49,12 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"ink-testing-library": "^3.0.0",
 		"prettier": "^2.8.7",
-		"ts-node": "^10.9.1",
-		"tsx": "^4.19.4",
-		"typescript": "^5.0.3",
-		"xo": "^0.54.2"
+                "ts-node": "^10.9.1",
+                "tsx": "^4.19.4",
+                "typescript": "^5.0.3",
+                "xo": "^0.54.2",
+                "jest": "^29.0.0",
+                "@types/jest": "^29.0.0"
 	},
 	"xo": {
 		"extends": "xo-react",

--- a/test.ts
+++ b/test.ts
@@ -1,46 +1,36 @@
-// This file is bananas-- i was using Ava, but it didn't work.
-// This needs to be reworked entirely
-
-// Simple standalone test without using ava
 import * as os from 'node:os';
-import { checkOs } from './src/utils/dependencies.js';
+import * as deps from './src/utils/dependencies.js';
 
-// Basic testing function
-function assertEqual(actual: any, expected: any, message: string) {
-	if (actual === expected) {
-		console.log(`✅ PASS: ${message}`);
-		return true;
-	}
+const { checkOs, checkDependencies } = deps;
 
-	console.error(`❌ FAIL: ${message}`);
-	console.error(`  Expected: ${expected}`);
-	console.error(`  Actual: ${actual}`);
-	return false;
-}
-
-// Run tests
-console.log('🧪 Running checkOs() test...');
-const directOs = os.platform();
-const funcOs = checkOs();
-
-// Verify the function returns the correct OS
-const test1 = assertEqual(funcOs, directOs, 'checkOs() should return the current platform');
-
-// Verify the OS is a known value
 const validPlatforms = ['darwin', 'linux', 'win32', 'aix', 'freebsd', 'openbsd', 'sunos'];
-const test2 = assertEqual(
-	validPlatforms.includes(funcOs),
-	true,
-	`Platform should be one of: ${validPlatforms.join(', ')}`,
-);
 
-// Summary
-console.log('\n--- Test Summary ---');
-console.log(`Platform detected: ${funcOs}`);
-if (test1 && test2) {
-	console.log('🎉 All tests passed!');
-	process.exit(0);
-} else {
-	console.error('⚠️ Some tests failed');
-	process.exit(1);
-}
+describe('checkOs', () => {
+       test('matches os.platform and returns a known platform', () => {
+               const directOs = os.platform();
+               const funcOs = checkOs();
+
+               expect(funcOs).toBe(directOs);
+               expect(validPlatforms).toContain(funcOs);
+       });
+});
+
+describe('checkDependencies', () => {
+       afterEach(() => {
+               jest.restoreAllMocks();
+       });
+
+       test('returns an array of dependency statuses', async () => {
+               jest.spyOn(deps, 'checkDocker').mockResolvedValue(true);
+               jest.spyOn(deps, 'checkPulumi').mockResolvedValue(false);
+               jest.spyOn(deps, 'checkNixpacks').mockResolvedValue(true);
+
+               const result = await checkDependencies();
+
+               expect(result).toEqual([
+                       { name: 'Docker', isInstalled: true },
+                       { name: 'Pulumi', isInstalled: false },
+                       { name: 'Nixpacks', isInstalled: true },
+               ]);
+       });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
 		"esm": true,
 		"experimentalSpecifierResolution": "node"
 	},
-	"include": ["src", "test.tsx", "test.tjs"]
+        "include": ["src", "test.ts", "test.tsx", "test.tjs"]
 }


### PR DESCRIPTION
## Summary
- replace node:test usage with Jest
- add Jest config and dependencies
- extend test coverage with dependency checks

## Testing
- `npm test` *(fails: jest not found)*